### PR TITLE
[feat] add plant & tag model classes and controllers

### DIFF
--- a/backend/controllers/plant.controller.js
+++ b/backend/controllers/plant.controller.js
@@ -9,13 +9,11 @@ const getListPlants = async (queryString) => {
                 include: Tag,
                 order : [['createdAt', 'DESC']]
             })
-            break;
         case "like":
             return await Plant.findAll({
                 include: Tag,
                 order: [['likes', 'DESC']]
             })
-            break;
         case "view":
             return await Plant.findAll({
                 include: Tag,
@@ -26,7 +24,6 @@ const getListPlants = async (queryString) => {
                 include: Tag,
                 order : [['createdAt', 'DESC']]
             })
-            break;
         //default action is same as recently order
     }
 }

--- a/backend/controllers/plant.controller.js
+++ b/backend/controllers/plant.controller.js
@@ -1,0 +1,22 @@
+const path = require('path');
+const Plant = require('../models/plant.model');
+
+const getListPlants = async (req, res) => {
+    //추후 로직 작성
+    //최신순, 인기순 정렬을 구현 쿼리 스트링 이용? 혹은 path param?
+    try {
+        const result = await Plant.findAll({
+            order: ['createdAt', 'DESC']
+        });
+        return res.json(result);
+    } catch (err) {
+        return res.status(500).json(err);
+    }
+}
+
+const getDetailPlant = (req, res) => {
+    //특정 식물의 자세한 내용을 리턴하는 로직 작성 필요
+}
+
+
+module.exports = { getListPlants , getDetailPlant };

--- a/backend/controllers/plant.controller.js
+++ b/backend/controllers/plant.controller.js
@@ -1,21 +1,48 @@
 const path = require('path');
 const Plant = require('../models/plant.model');
+const Tag = require('../models/tag.model');
 
-const getListPlants = async (req, res) => {
-    //추후 로직 작성
-    //최신순, 인기순 정렬을 구현 쿼리 스트링 이용? 혹은 path param?
-    try {
-        const result = await Plant.findAll({
-            order: ['createdAt', 'DESC']
-        });
-        return res.json(result);
-    } catch (err) {
-        return res.status(500).json(err);
+const getListPlants = async (queryString) => {
+    switch (queryString) {
+        case "recent":
+            return await Plant.findAll({
+                include: Tag,
+                order : [['createdAt', 'DESC']]
+            })
+            break;
+        case "like":
+            return await Plant.findAll({
+                include: Tag,
+                order: [['likes', 'DESC']]
+            })
+            break;
+        case "view":
+            return await Plant.findAll({
+                include: Tag,
+                order: [['views', 'DESC']]
+            })
+        default:
+            return await Plant.findAll({
+                include: Tag,
+                order : [['createdAt', 'DESC']]
+            })
+            break;
+        //default action is same as recently order
     }
 }
 
-const getDetailPlant = (req, res) => {
-    //특정 식물의 자세한 내용을 리턴하는 로직 작성 필요
+const getDetailPlant = async (plantId) => {
+    const response = await Plant.findByPk((plantId), {
+        include : Tag
+    });
+    const views = response["views"];
+    //조회수 업데이트
+    await Plant.update({
+        views: views + 1
+    }, {
+        where: { id : plantId }
+    });
+    return response;
 }
 
 

--- a/backend/models/index.js
+++ b/backend/models/index.js
@@ -3,12 +3,41 @@ const env = process.env.NODE_ENV || 'development';
 const {development,production,test} = require('../config/config');
 const db = {};
 const User = require('./user.model');
+const Plant = require('./plant.model');
+const Tag = require('./tag.model');
 
 const sequelize = new Sequelize(development.database,development.username,development.password,development);
 db.sequelize = sequelize;
 
 db.User = User;
+db.Plant = Plant;
+db.Tag = Tag;
+
 User.init(sequelize);
 User.associate(db);
+
+Plant.init(sequelize);
+Plant.associate(db);
+
+Tag.init(sequelize);
+Tag.associate(db);
+
+//추후 각 모델을 init & associate 하는 로직을 추가해야 합니다.
+// const fs = require('fs);
+// fs
+//   .readdirSync(__dirname)
+//   .filter(file => {
+//     return (file.indexOf('.') !== 0) && (file !== basename) && (file.slice(-3) === '.js');
+//   })
+//   .forEach(file => {
+//     const model = require(path.join(__dirname, file))(sequelize, Sequelize.DataTypes);
+//     db[model.name] = model;
+//   });
+
+// Object.keys(db).forEach(modelName => {
+//   if (db[modelName].associate) {
+//     db[modelName].associate(db);
+//   }
+// });
 
 module.exports = db;

--- a/backend/models/plant.model.js
+++ b/backend/models/plant.model.js
@@ -1,0 +1,37 @@
+const Sequelize = require('sequelize');
+
+module.exports = class Plant extends Sequelize.Model{
+    static init(sequelize){
+        return super.init({
+            name:{
+                type: Sequelize.STRING(50),
+                allowNull: false,
+            },
+            feature:{
+                type: Sequelize.STRING(2000),
+            },
+            imagePath:{
+                type: Sequelize.STRING(500),
+                allowNull: false
+            }
+            //그 외 속성 추가해야 합니다.
+        }, {
+            sequelize,
+            timestamp: false,
+            underscored: false,
+            modelName: 'Plant',
+            tableName: 'plants',
+            paranoid:false,
+            charset:'utf8',
+            collate:'utf8_general_ci',
+        });
+    }
+    static associate(db){
+        Plant.belongsToMany(models.Tag, {
+            through: 'PlantTags'
+        });
+        //N:M 관게를 PlantTags라는 Junction Table을 만들어 관리합니다.
+        //PlantTags라는 테이블은 Plant의 id와 Tag의 id를 외래키로 갖고
+        //두 외래키의 조합을 PK로 사용하는 테이블입니다.
+    }
+}

--- a/backend/models/plant.model.js
+++ b/backend/models/plant.model.js
@@ -3,21 +3,62 @@ const Sequelize = require('sequelize');
 module.exports = class Plant extends Sequelize.Model{
     static init(sequelize){
         return super.init({
-            name:{
+            name:{ //꽃의 이름
                 type: Sequelize.STRING(50),
                 allowNull: false,
             },
-            feature:{
-                type: Sequelize.STRING(2000),
+            feature:{ //반전매력
+                type: Sequelize.STRING(2000)
             },
-            imagePath:{
+            warning: {//주의할점
+                type: Sequelize.STRING(2000)
+            },
+            place : { //장소
+                type: Sequelize.STRING(2000)
+            },
+            grow : { //성장속도
+                type: Sequelize.STRING(2000)
+            },
+            difficulty : { //난이도
+                type: Sequelize.STRING(50)
+            },
+            water : { //물 주기
+                type : Sequelize.STRING(50)
+            },
+            height : { //크기
+                type: Sequelize.STRING(2000)
+            },
+            description : { //한문장 요약
+                type: Sequelize.STRING(100)
+            },
+            ment : { //멘트
+                type: Sequelize.STRING(2000)
+            },
+            flower : { //개화여부
+                type : Sequelize.BOOLEAN
+            },
+            temperature: { //온도
+                type: Sequelize.STRING(50)
+            },
+            views : { //추후 조회수 기반 정렬을 위해 구현
+                type : Sequelize.INTEGER,
+                default: 0
+            },
+            likes : { //추후 인기순 기반 정렬을 위해 구현
+                type: Sequelize.INTEGER,
+                default: 0
+            },
+            imagePath:{ // 디테일 화면 메인 이미지
+                type: Sequelize.STRING(500),
+                allowNull: false
+            },
+            thumbnailPath:{ //리스트로 볼때의 썸네일 이미지
                 type: Sequelize.STRING(500),
                 allowNull: false
             }
-            //그 외 속성 추가해야 합니다.
         }, {
             sequelize,
-            timestamp: false,
+            timestamp: true,
             underscored: false,
             modelName: 'Plant',
             tableName: 'plants',

--- a/backend/models/tag.model.js
+++ b/backend/models/tag.model.js
@@ -1,0 +1,26 @@
+const Sequelize = require('sequelize');
+
+module.exports = class Tag extends Sequelize.Model{
+    static init(sequelize){
+        return super.init({
+            name:{
+                type: Sequelize.STRING(50),
+                allowNull: false,
+            }
+        }, {
+            sequelize,
+            timestamp: false,
+            underscored: false,
+            modelName: 'Tag',
+            tableName: 'tags',
+            paranoid:false,
+            charset:'utf8',
+            collate:'utf8_general_ci',
+        });
+    }
+    static associate(db){
+        Tag.belongsToMany(models.Plant, {
+            through: 'PlantTags'
+        });
+    }
+}

--- a/backend/routes/plants.route.js
+++ b/backend/routes/plants.route.js
@@ -1,5 +1,5 @@
 const express = require('express');
-
+const { getListPlants, getDetailPlant  } = require('../controllers/plant.controller');
 const router = express.Router()
 
 router.post('/curating',(req,res)=>{
@@ -34,6 +34,36 @@ router.post('/curating',(req,res)=>{
             })
     }
    
+})
+
+router.get('/', async (req, res) => {
+  try {
+      const result = await getListPlants(req.query.order); //쿼리스트링. /plants?order=recent
+      res.json({
+          success: true,
+          message : result
+      });
+  } catch (err) {
+      res.json({
+          success: false,
+          message: err
+      });
+  }
+});
+
+router.get('/:plantId', async (req, res) => {
+    try {
+        const result = await getDetailPlant(req.params.plantId);
+        res.json({
+            success: true,
+            message : result
+        })
+    } catch (err) {
+        res.json({
+            success: false,
+            message: err
+        })
+    }
 })
 
 module.exports = router;


### PR DESCRIPTION
- add Tag class with implementaion of Tag class's associate method with belongsToMany
- add Plant class with implementaiton of Plant class's associate method with belongsToMany
- add controller for example logic with findAll method & async arrow function

현재 작업진행중입니다. 

태그와 식물 테이블을 생성하기 위한 클래스를 작성했으며, 식물 클래스의 경우 아직 모든 속성을 기입하진 않았습니다.

식물 테이블과 태그 테이블은 belongsToMany 메서드를 각 클래스의 associate 이라는 스태틱 메서드에 구현하면 됩니다.

```js
    static associate(db){
        Tag.belongsToMany(models.Plant, {
            through: 'PlantTags'
        });
```

junction table을 자동으로 생성해주는데 이 때 이름을 `PlantTags`로 네이밍 하였습니다.

또한 이 junction table은 디폴트 동작이 plant의 id와 tag의 id를 외래키로 가지며 두 키의 조합을 기본키로 사용하는 테이블입니다.
