### PR TITLE
[feat] Add Button component and theme properties

### DIFF
--- a/frontend/src/index.tsx
+++ b/frontend/src/index.tsx
@@ -5,11 +5,13 @@ import reportWebVitals from './reportWebVitals';
 
 import {ThemeProvider} from 'styled-components';
 import theme from './styles/theme';
+import GlobalStyle from './styles/GlobalStyle';
 
 ReactDOM.render(
   <React.StrictMode>
     <ThemeProvider theme={theme}>
       <App />
+      <GlobalStyle />
     </ThemeProvider>
   </React.StrictMode>,
   document.getElementById('root')

--- a/frontend/src/lib/calculate.js
+++ b/frontend/src/lib/calculate.js
@@ -1,0 +1,6 @@
+import theme from '../styles/theme';
+
+export const getVW = (origin) => {
+  const result = (origin / theme.size.md) * 100;
+  return `${Math.round(result * 10) / 10}vw`;
+};

--- a/frontend/src/styles/Button.js
+++ b/frontend/src/styles/Button.js
@@ -1,0 +1,43 @@
+import styled from 'styled-components';
+import {getVW} from '../lib/calculate';
+
+const fontSizes = {
+  md: 30,
+  lg: 32,
+};
+
+const Button = styled.button`
+  width: 640px;
+  height: 100px;
+
+  border-radius: 20px;
+  border: 2px solid ${({theme, borderColor}) => theme.colors[borderColor]};
+  background-color: ${({theme, bgColor}) => theme.colors[bgColor]};
+
+  font-size: ${({fontSize}) => fontSizes[fontSize]}px;
+  font-weight: ${({theme, fontWeight}) => theme.fontWeights[fontWeight]};
+  color: ${({theme, color}) => theme.colors[color]};
+
+  @media ${({theme}) => theme.devices.md} {
+    width: max(320px, ${getVW(640)});
+    height: max(50px, ${getVW(100)});
+    font-size: max(16px, ${({fontSize}) => getVW(fontSizes[fontSize])});
+  }
+
+  @media ${({theme}) => theme.devices.sm} {
+    border-radius: ${({borderRadius}) => borderRadius}px;
+    border-width: 1px;
+    font-weight: ${({theme}) => theme.fontWeights.medium};
+  }
+`;
+
+Button.defaultProps = {
+  borderRadius: 10, // mobile ver, desktop default 20
+  borderColor: 'white',
+  bgColor: 'white',
+  color: 'green',
+  fontSize: 'md', // desktop ver, mobile default 16
+  fontWeight: 'medium', // desktop ver, mobile default medium
+};
+
+export default Button;

--- a/frontend/src/styles/GlobalStyle.js
+++ b/frontend/src/styles/GlobalStyle.js
@@ -1,0 +1,16 @@
+import {createGlobalStyle} from 'styled-components';
+
+const GlobalStyle = createGlobalStyle`
+@import url('https://fonts.googleapis.com/css2?family=Noto+Sans+KR:wght@400;500;700&display=swap');
+
+  * {
+      font-family: 'Noto Sans KR', sans-serif;
+  }
+  
+  button {
+    cursor: pointer;
+    outline: none;
+  }
+`;
+
+export default GlobalStyle;

--- a/frontend/src/styles/theme.js
+++ b/frontend/src/styles/theme.js
@@ -1,11 +1,36 @@
 const colors = {
+  white: 'white',
   green: '#2A845D',
   lightGreen: '#8CD29C',
   skyBlue: '#5CACC5',
 };
 
+const fontWeights = {
+  bold: 700,
+  medium: 500,
+  regular: 400,
+};
+
+const width = {
+  content: 841,
+  padding: 20,
+};
+
+const size = {
+  sm: 360,
+  md: width.content - 1 + width.padding * 2,
+};
+
+const devices = {
+  sm: `(max-width: ${size.sm}px)`,
+  md: `(max-width: ${size.md}px)`,
+};
+
 const theme = {
   colors,
+  fontWeights,
+  size,
+  devices,
 };
 
 export default theme;


### PR DESCRIPTION
* 관련 이슈 : #34 
* Button 컴포넌트 추가
* width 사이즈 줄어드는 구간 임시 설정 -> **361px~ 880px (모바일: 360px 이하, 데스크탑: 881px 이상**
* theme 공통 스타일 추가
* 추후 회의 필요한 내용

## 1. Button 컴포넌트 추가

1. 특별한 props를 주지 않으면 `Button.js` 내의 `defaultProps`에 있는 스타일 적용
2. `defaultProps`에서 주석이 있는 값은 데스크탑과 모바일 스타일이 달라서 특정 화면에 대한 스타일 정의하는 부분
```javascript
Button.defaultProps = {
  borderRadius: 10, // mobile ver, desktop default 20 -> 데스크탑에서는 항상 20px이므로 모바일 스타일 설정 (설정하지 않으면 모바일에서 항상 10px)
  ...
  fontSize: 'md', // desktop ver, mobile default 16  -> 모바일에서는 항상 16px이므로 데스크탑 스타일 설정 (설정하지 않으면 데스크탑에서 항상 md px)
  fontWeight: 'medium', // desktop ver, mobile default medium -> 모바일에서는..
};
```
3. 사용 예시
```html
<Button fontWeight="bold">테스트 GO!</Button>
<Button borderColor="lightGreen" fontWeight="bold" color="lightGreen">
  다른 키워드로 검색
</Button>
<Button>
      그 사람을 알아가는 데<br />
      많은 시간과 노력이 필요한 편이다
</Button>
<Button bgColor="lightGreen" fontSize="lg" color="white">
      결과 공유하기
</Button>
<Button borderColor="lightGreen" fontSize="lg" color="lightGreen">
      결과 저장하기
</Button>
```

## 2. theme 공통 스타일 추가
1. 데스크탑~모바일 중간 부분에서 특별한 사이즈 대응이 없어서 **881px**보다 줄어들 때
_881px = 회의했던 content 가로 길이(841px) + 모바일 최소 패딩(20*2=40px)_
버튼 사이즈가 비율대로 줄어들도록 해봤습니다 (`theme.size.md` : 881px)
2. `fontSize`는 서비스 전체 컴포넌트마다 조금씩 달라서 일단 `Button` 컴포넌트 내에 변수로 추가했어요!

## 3. 추후 회의 필요한 내용
* 모바일 사이즈 대응을 임시로 360px로 했는데 디자인 파일은 그대로 참고하되 적용 구간만 더 늘려야 할 거 같아요..! 버튼을 하다 보니까 모바일 적용 스타일이 너무 많이 줄여야 적용되는 거 같았습니다 ex) 400px 이하..?

<hr>

사이즈 대응 틀도 잡을 겸 버튼 이외에도 많이 추가돼서 좀 길어졌어요 😂 리뷰 부탁드립니다..!
@choisohyun 