### PR TITLE
Feature/front/recommend plant

### DIFF
--- a/frontend/src/components/RecommentPlant.jsx
+++ b/frontend/src/components/RecommentPlant.jsx
@@ -1,0 +1,16 @@
+import React from 'react';
+import styled from "styled-components";
+
+function RecommendPlant() {
+  return (
+    <>
+      <Wrapper>
+
+      </Wrapper>
+    </>
+  );
+}
+
+const Wrapper = styled.div``;
+
+export default RecommendPlant;

--- a/frontend/src/components/RecommentPlant.jsx
+++ b/frontend/src/components/RecommentPlant.jsx
@@ -1,16 +1,91 @@
 import React from 'react';
 import styled from "styled-components";
+import TagList from "./TagList";
+import {getVW} from "../lib/calculate";
 
-function RecommendPlant() {
+/*
+plant {
+  img: string;
+  title: string;
+  description: string;
+  tagData: string[];
+}
+*/
+function RecommendPlant({plant}) {
   return (
-    <>
-      <Wrapper>
-
-      </Wrapper>
-    </>
+    <Wrapper>
+      <Image imgUrl={plant.img} />
+      <Title>{plant.title}</Title>
+      <Description>{plant.description}</Description>
+      <TagList tagData={plant.tagData} key={plant.title} />
+    </Wrapper>
   );
 }
 
-const Wrapper = styled.div``;
+const borderRadius = `max(30px, ${getVW(45)})`;
+
+const Wrapper = styled.div`
+  width: 352.5px;
+  height: 517.5px; 
+  margin-left: 20px;
+  border-radius: 45px 45px 45px 0px; 
+  box-shadow: 0px 25px 35px 0px rgba(0, 0, 0, 0.04);
+
+  @media ${({theme}) => theme.devices.md} {
+    width: max(235px, ${getVW(352.5)});
+    height: max(345px, ${getVW(517.5)});
+    border-radius: ${borderRadius} ${borderRadius} ${borderRadius} 0px; 
+    box-shadow: 0px 25px 35px 0px rgba(0, 0, 0, 0.04);
+  }
+  @media ${({theme}) => theme.devices.sm} {
+    box-shadow: 0px 14px 25px 0px rgba(0, 0, 0, 0.05);
+  }
+`;
+
+const Image = styled.img`
+  width: 352.5px;
+  height: 352.5px;
+  content: url(${({imgUrl}) => imgUrl});
+  border-radius: 45px 45px 0 0; 
+
+  @media ${({theme}) => theme.devices.md} {
+    width: max(235px, ${getVW(352.5)});
+    height: max(235px, ${getVW(352.5)});
+  }
+  @media ${({theme}) => theme.devices.sm} {
+    border-radius: 30px 30px 0 0; 
+  }
+`;
+
+const Title = styled.h2`
+  font-style: normal;
+  font-weight: bold;
+  font-size: 24px;
+  line-height: 35px;
+  color: #2A845D;
+  margin: 19.5px 24px 0;
+  
+  @media ${({theme}) => theme.devices.md} {
+    font-size: max(16px, ${getVW(24)});
+    line-height: max(23px, ${getVW(35)});
+    margin: max(13px, ${getVW(19.5)}) max(16px, ${getVW(24)}) 0;
+  }
+`;
+
+const Description = styled.span`
+  font-size: 21px;
+  line-height: 30px;
+  color: rgba(0, 0, 0, 0.6);
+  margin: 2px 24px 7.5px;
+  
+  @media ${({theme}) => theme.devices.md} {
+    font-size: max(14px, ${getVW(21)});
+    line-height: max(20px, ${getVW(30)});
+    margin: max(0, ${getVW(2)}) max(16px, ${getVW(24)}) max(0, ${getVW(7.5)});
+  }
+  @media ${({theme}) => theme.devices.sm} {
+    margin: 0 16px 0;
+  }
+`;
 
 export default RecommendPlant;

--- a/frontend/src/components/TagList.jsx
+++ b/frontend/src/components/TagList.jsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import styled from "styled-components";
+import {getVW} from "../lib/calculate";
 
 
 /*
@@ -14,24 +15,40 @@ function TagList({tagData}) {
 }
 
 const Wrapper = styled.ul`
-  margin: 0 16px;
+  margin: 0 24px;
+  
+  @media ${({theme}) => theme.devices.md} {
+    margin: 0 max(16px, ${getVW(24)});
+  }
 `
 
 const Tag = styled.li`
-  border-radius: 50.24px;
   border: 1px solid rgba(0, 0, 0, 0.15);;
-  height: 33.09796905517578px;
   display: inline-block;
-  padding: 6px 14px;
-  margin: 5px 4px;
+  background: ${({theme}) => theme.colors.white};
+  border-radius: 74.2px;
+  height: 49.5px;
+  margin: 5px 4px 5px 0;
+  padding: 9.5px 20px;
+  
+  @media ${({theme}) => theme.devices.md} {
+    border-radius: max(50px, ${getVW(74.2)});
+    height: max(33px, ${getVW(49.5)});
+    padding: max(6px, ${getVW(9.5)}) max(14px, ${getVW(20)});
+  }
 `
 
 const Text = styled.span`
   font-style: normal;
   font-weight: normal;
-  font-size: 14px;
-  line-height: 20px;
+  font-size: 21px;
+  line-height: 30px;
   color: rgba(0, 0, 0, 0.6);
+  
+  @media ${({theme}) => theme.devices.md} {
+    font-size: max(14px, ${getVW(21)});
+    line-height: max(20px, ${getVW(30)});
+  }
 `
 
 export default TagList;


### PR DESCRIPTION
관련이슈 : #34 

### 작업 내용

- 메인 페이지의 추천 식물(요즘 뜨는 친구들) 식물 1개의 컴포넌트 만들었습니다
- TagList와 RecommendPlant 함께 반응형 적용했습니다
반응형 스타일에 약해서.. 승아님 코드 참고해서 적용했어요! 어색한 부분이 있을 수 있는데 계속 수정해 보겠습니다~! 

모바일
![Screen Shot 2021-02-07 at 15 22 42](https://user-images.githubusercontent.com/30427711/107138561-6657ca00-6958-11eb-918a-fe79272646b5.png)

PC
![Screen Shot 2021-02-07 at 15 22 52](https://user-images.githubusercontent.com/30427711/107138565-69eb5100-6958-11eb-9772-6b7faf653164.png)


사용예
```js
  const plantData = {
    img: 'https://seeat-image-dev-image-bucket.s3.ap-northeast-2.amazonaws.com/%E1%84%80%E1%85%AA%E1%86%AB%E1%84%8B%E1%85%B3%E1%86%B7%E1%84%8C%E1%85%AE%E1%86%A8.png',
    title: '몬스테라',
    description: '바쁜 일상 속 조용한 힐링',
    tagData: ['💧💧', '#보통크기'],
  }

  return (
    <>
      <RecommendPlant plant={plantData} />
    </>
  );
```

### 디자인팀 확인 필요 요소

- 추천 식물의 태그가 3개일 때 글자수가 많은 것들이 오게 되면 width가 지정된 것보다 넘어가게 되어 태그를 2개만 올 수 있게 하거나 height를 늘릴 수 있는 방안 필요

![Screen Shot 2021-02-07 at 15 29 06](https://user-images.githubusercontent.com/30427711/107138721-5a203c80-6959-11eb-9f1c-4b7f835700b7.png)

리뷰 감사합니다~! 😻
