### PR TITLE
[feat] query without junction table's attributes

### DIFF
--- a/backend/controllers/plant.controller.js
+++ b/backend/controllers/plant.controller.js
@@ -14,16 +14,6 @@ const getListPlants = async (queryString) => {
                 }],
                 order : [['createdAt', 'DESC']]
             })
-        case "like":
-            return await Plant.findAll({
-                include : [{
-                    model: Tag,
-                    through: {
-                        attributes: []
-                    }
-                }],
-                order: [['likes', 'DESC']]
-            })
         case "view":
             return await Plant.findAll({
                 include : [{

--- a/backend/controllers/plant.controller.js
+++ b/backend/controllers/plant.controller.js
@@ -6,17 +6,32 @@ const getListPlants = async (queryString) => {
     switch (queryString) {
         case "recent":
             return await Plant.findAll({
-                include: Tag,
+                include : [{
+                    model: Tag,
+                    through: {
+                        attributes: [] // junction Table (PlantTags)로부터 쓸데없는 정보를 받지 않기 위한 옵션
+                    }
+                }],
                 order : [['createdAt', 'DESC']]
             })
         case "like":
             return await Plant.findAll({
-                include: Tag,
+                include : [{
+                    model: Tag,
+                    through: {
+                        attributes: []
+                    }
+                }],
                 order: [['likes', 'DESC']]
             })
         case "view":
             return await Plant.findAll({
-                include: Tag,
+                include : [{
+                    model: Tag,
+                    through: {
+                        attributes: []
+                    }
+                }],
                 order: [['views', 'DESC']]
             })
         default:
@@ -30,7 +45,12 @@ const getListPlants = async (queryString) => {
 
 const getDetailPlant = async (plantId) => {
     const response = await Plant.findByPk((plantId), {
-        include : Tag
+        include : [{
+            model: Tag,
+            through: {
+                attributes: []
+            }
+        }]
     });
     const views = response["views"];
     //조회수 업데이트


### PR DESCRIPTION
Eager-loading을 이용하여 M:N 관계에 있는 내용을 쿼리할 때.

```js
    const response = await Plant.findByPk((plantId), {
        include : Tag
    });
```

와 같이 작성하면 junction Table 안에 있는 내용들까지 쿼리됩니다.

junction Table에 있는 내용은 저희가 소모하지 않을 내용입니다 (각 외래키의 값 및 생성/업데이트 일자)

따라서 위 코드를 다음과 같이 수정합니다.

```js
    const response = await Plant.findByPk((plantId), {
        include : [{
            model: Tag,
            through: {
                attributes: []
            }
        }]
    });
```

위와 같이 수정하면 junction table에 있는 쓸데없는 정보를 제외하고 쿼리 가능합니다.