### PR TITLE
[feat] add document about jenkins for backup

### DIFF
--- a/backend/jenkins/README.md
+++ b/backend/jenkins/README.md
@@ -1,0 +1,8 @@
+# Jenkins
+
+- 프론트 & 백엔드 배포 자동화
+    - 현재 Github webhook 연결. PR 머지시 프론트 & 백 동시 배포
+    
+- 배포 process는 .groovy에서 확인 가능
+
+- 주소 : http://sehwanzzang.com:8080/

--- a/backend/jenkins/back.groovy
+++ b/backend/jenkins/back.groovy
@@ -1,0 +1,44 @@
+def ACCESS_KEY_ID = ""
+def SECRET_ACCESS_KEY = ""
+
+pipeline {
+    agent any
+    tools {
+        nodejs "node14"
+        git "git"
+    }
+
+    stages {
+        stage('prepare') {
+            steps {
+                dir('test_dir'){
+                git branch: "${BRANCH}", credentialsId: "GIT_ACCOUNT", url: 'https://github.com/dnd-mentee-4th/dnd-mentee-4th-9-repo.git'
+                    sh 'ls -al'
+                    sh 'cp /var/lib/jenkins/.env ./backend'
+                }
+            }
+        }
+        stage('build') {
+            steps {
+                dir('test_dir'){
+                    dir('backend'){
+                    sh 'ls -al'
+                     sh 'docker build --tag dnd-9th:1.0 .'
+                    }
+                }
+            }
+        }
+        stage('deploy') {
+            steps {
+                dir('test_dir'){
+                    sh 'ls -al'
+                    dir('backend'){
+                        sh 'docker-compose down'
+                        sh 'docker-compose up -d --build'
+                    }
+
+                }
+            }
+        }
+    }
+}

--- a/backend/jenkins/front.groovy
+++ b/backend/jenkins/front.groovy
@@ -1,0 +1,34 @@
+def ACCESS_KEY_ID = "AWS_ACCESS_KEY_ID"
+def SECRET_ACCESS_KEY = "AWS_SECRET_ACCESS_KEY"
+
+pipeline {
+    agent any
+    tools {
+        nodejs "node14"
+        git "git"
+    }
+
+    stages {
+        stage('prepare') {
+            steps {
+                    git branch: "${BRANCH}", credentialsId: "GIT_ACCOUNT", url: 'https://github.com/dnd-mentee-4th/dnd-mentee-4th-9-repo.git'
+            }
+        }
+        stage('build') {
+            steps {
+                    dir('frontend'){
+                        sh "yarn install"
+                        sh "CI=false yarn build"
+                }
+            }
+        }
+        stage('deploy') {
+            steps {
+                dir('frontend'){
+                sh "aws s3 sync ./build s3://dnd-4th-9-see-at --profile default"
+                echo 'deploy done.'
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
현재 Github webhook과 jenkins를 연동하였습니다.

따라서 PR 머지 될 경우 프론트와 백엔드 동시에 배포 진행됩니다. 

필요에 따라서는 webhook 제거 후 수동 배포를 고려해보아야 겠습니다 :) 

<img width="1624" alt="스크린샷 2021-02-12 오전 3 04 36" src="https://user-images.githubusercontent.com/59886140/107678679-0ad26700-6cdf-11eb-8bf1-a87b0fe50044.png">

<img width="1624" alt="스크린샷 2021-02-12 오전 3 04 53" src="https://user-images.githubusercontent.com/59886140/107678721-16be2900-6cdf-11eb-9cdb-234d168f597b.png">
