### PR TITLE
Fix/backend/search api

### DIFF
--- a/backend/controllers/plant.controller.js
+++ b/backend/controllers/plant.controller.js
@@ -140,9 +140,9 @@ const curatingResult = async (req, res, next) => {
 
 const searchByPlantName = async (req, res, next) => {
     try {
-        const searchResult = await Plant.findOne({
+        const searchResult = await Plant.findAll({
             attributes: ['id', 'name', 'description', 'thumbnailPath'],
-            where: {name: req.body.keyword},
+            where: {name: {[Op.like]:`${req.body.keyword}%`}},
             include: [{
                 model: Tag,
                 attributes: ['id', 'name'],

--- a/backend/controllers/plant.controller.js
+++ b/backend/controllers/plant.controller.js
@@ -123,7 +123,7 @@ const curatingResult = async (req, res, next) => {
     try {
         const resultPlant = await Plant.findOne({
             attributes: ['id', 'name', 'description', 'ment', 'imagePath'],
-            where: {name: req.body.plant},
+            where: {name: req.query.result},
             include: [{
                 model: Tag,
                 attributes: ['id', 'name'],
@@ -138,7 +138,7 @@ const curatingResult = async (req, res, next) => {
     }
 }
 
-const keywordSearch = async (req, res, next) => {
+const searchByPlantName = async (req, res, next) => {
     try {
         const searchResult = await Plant.findOne({
             attributes: ['id', 'name', 'description', 'thumbnailPath'],
@@ -157,7 +157,7 @@ const keywordSearch = async (req, res, next) => {
     }
 }
 
-const tagSearch = async(req,res,next)=>{
+const searchByPlantTag = async(req,res,next)=>{
     try{
         const tags = req.body.tags.split(',');
         const tagSearchResult = await Plant.findAll({
@@ -178,4 +178,4 @@ const tagSearch = async(req,res,next)=>{
 }
 
 
-module.exports = { getListPlants , getDetailPlant, curatingResult,keywordSearch,tagSearch};
+module.exports = { getListPlants , getDetailPlant, curatingResult,searchByPlantName,searchByPlantTag};

--- a/backend/routes/plants.route.js
+++ b/backend/routes/plants.route.js
@@ -1,14 +1,14 @@
 const express = require('express');
-const { getListPlants, getDetailPlant,curatingResult,keywordSearch,tagSearch} = require('../controllers/plant.controller');
+const { getListPlants, getDetailPlant,curatingResult,searchByPlantName,searchByPlantTag} = require('../controllers/plant.controller');
 const router = express.Router()
 
 
 router.get('/', getListPlants) //쿼리스트링. /plants?order=recent});
 
-router.post('/curating',curatingResult);
+router.get('/curating',curatingResult);
 
-router.post('/encyclopedia/keyword',keywordSearch);
-router.post('/encyclopedia/tag',tagSearch);
+router.post('/encyclopedia/keyword',searchByPlantName);
+router.post('/encyclopedia/tag',searchByPlantTag);
 
 router.get('/:plantId', getDetailPlant) //for detail
 


### PR DESCRIPTION
식물 이름으로 검색하는 api 수정했습니다

```js
const searchByPlantName = async (req, res, next) => {
    try {
        const searchResult = await Plant.findAll({
            attributes: ['id', 'name', 'description', 'thumbnailPath'],
            where: {name: {[Op.like]:`${req.body.keyword}%`}},
            include: [{
                model: Tag,
                attributes: ['id', 'name'],
                through: {
                    attributes: []
                }
            }]
        });
        res.json(searchResult);
    } catch (error) {
        next(error);
    }
}
```

큐레이팅 결과 post에서 get으로 변경했습니다.

```js
const curatingResult = async (req, res, next) => {
    try {
        const resultPlant = await Plant.findOne({
            attributes: ['id', 'name', 'description', 'ment', 'imagePath'],
            where: {name: req.query.result},
            include: [{
                model: Tag,
                attributes: ['id', 'name'],
                through: {
                    attributes: []
                }
            }]
        });
        res.json(resultPlant);
    } catch (error) {
        next(error);
    }
}
```

이슈였던 변수명도 변경되었습니다