### PR TITLE
[feat] add full size image path

### DIFF
--- a/backend/setup.js
+++ b/backend/setup.js
@@ -14,7 +14,7 @@ const reset = async () => {
                 "3. 2~3년에 한번씩 배수가 잘 되는 흙으로 분갈이가 필요해요.",
             description: "바쁜 일상 속 조용한 힐링",
             ment: "몬스테라는 크고 특이하게 갈라진 잎이 매력적인 친구이며, 크기도 적당해서 플랜테리어 식물로 유명하답니다. 또한 관리가 쉽고 환경 변화에 크게 예민하지 않아 식물을 키운 경험이 적은 초보 식물 집사에게 인기가 많아요. 예쁘게 자라는 모습도 눈에 잘 들어옵니다. 단, 직사광선보다는 밝은 창가가, 많은 물을 필요로 하지 않는 만큼 과습에 주의해준다면 더욱 잘 자란답니다.",
-            imagePath: "https://seeat-image-dev-image-bucket.s3.ap-northeast-2.amazonaws.com/%E1%84%86%E1%85%A9%E1%86%AB%E1%84%89%E1%85%B3%E1%84%90%E1%85%A6%E1%84%85%E1%85%A1.png",
+            imagePath: "https://seeat-image-dev-image-bucket.s3.ap-northeast-2.amazonaws.com/%E1%84%86%E1%85%A9%E1%86%AB%E1%84%89%E1%85%B3%E1%84%90%E1%85%A6%E1%84%85%E1%85%A1_full.png",
             thumbnailPath: "https://seeat-image-dev-image-bucket.s3.ap-northeast-2.amazonaws.com/%E1%84%86%E1%85%A9%E1%86%AB%E1%84%89%E1%85%B3%E1%84%90%E1%85%A6%E1%84%85%E1%85%A1.png"
         },
         // 아레카야자 id : 2
@@ -27,7 +27,7 @@ const reset = async () => {
                 "3. 어린 아레카야자의 경우 1년에 한 번, 성체의 경우 2~3년에 한 번 분갈이가 필요해요.",
             description: "따뜻한 위로를 전하는 친구",
             ment: "아레카야자는 NASA에서 공기정화능력 1등으로 선정된 식물이에요. 큰 키는 대나무를 연상시켜 온화함을 주고, 증산량이 높아 건조한 실내를 촉촉하게 해준답니다. 식물 경험이 적은 초보자도 키우기 쉽지만, 통풍과 볕이 잘 드는 곳을 요구하며 분무기로 잎은 촉촉하게 해주는 등 관리는 필요해요. 나의 정성만큼 빠르게 성장하는 아레카야자를 보면 오늘의 걱정을 잠시 잊게 될 거에요.",
-            imagePath: "https://seeat-image-dev-image-bucket.s3.ap-northeast-2.amazonaws.com/%E1%84%8B%E1%85%A1%E1%84%85%E1%85%A6%E1%84%8F%E1%85%A1%E1%84%8B%E1%85%A3%E1%84%8C%E1%85%A1.png",
+            imagePath: "https://seeat-image-dev-image-bucket.s3.ap-northeast-2.amazonaws.com/%E1%84%8B%E1%85%A1%E1%84%85%E1%85%A6%E1%84%8F%E1%85%A1%E1%84%8B%E1%85%A3%E1%84%8C%E1%85%A1_full.png",
             thumbnailPath: "https://seeat-image-dev-image-bucket.s3.ap-northeast-2.amazonaws.com/%E1%84%8B%E1%85%A1%E1%84%85%E1%85%A6%E1%84%8F%E1%85%A1%E1%84%8B%E1%85%A3%E1%84%8C%E1%85%A1.png"
         },
         // 아이비 id : 3
@@ -39,7 +39,7 @@ const reset = async () => {
                 "2. 1년 주기로 봄, 가을에 배양토로 분갈이를 해주세요.",
             description: "작고 귀여운 덩굴 식물",
             ment: "아이비는 품종이 500종 이상인 대표적인 플랜테리어 식물이에요. 잎이 하트 모양이거나 특이한 색(무늬)을 가져 귀여움을 자랑합니다. 아담한 사이즈로 길이가 길면 벽에 걸어두어 자연의 느낌을, 짧으면 미니 화분에 심을 수 있습니다. 초보자도 키우기 쉬우며 우수한 공기정화 능력은 덤이에요! 단, 햇빛이 잘 드는 장소에서 분무기로 물을 자주 주어야 하고, 수경 재배도 가능합니다.",
-            imagePath: "https://seeat-image-dev-image-bucket.s3.ap-northeast-2.amazonaws.com/%E1%84%8B%E1%85%A1%E1%84%8B%E1%85%B5%E1%84%87%E1%85%B5.png",
+            imagePath: "https://seeat-image-dev-image-bucket.s3.ap-northeast-2.amazonaws.com/%E1%84%8B%E1%85%A1%E1%84%8B%E1%85%B5%E1%84%87%E1%85%B5_full.png",
             thumbnailPath: "https://seeat-image-dev-image-bucket.s3.ap-northeast-2.amazonaws.com/%E1%84%8B%E1%85%A1%E1%84%8B%E1%85%B5%E1%84%87%E1%85%B5.png"
         },
         // 관음죽 id : 4
@@ -52,7 +52,7 @@ const reset = async () => {
                 "3. 2년에 한 번씩 봄에 큰 화분이나 작은 화분에 포기나누기를 해주세요.",
             description: "진정한 반려 식물의 의미",
             ment: "관음죽은 긴 잎에 줄무늬를 가졌어요. 공기 정화와 암모니아 냄새 제거에 탁월하고 낮은 온도(그늘)에서도 잘 자랍니다. 오랜 정성을 들이면 드물게 피우는 꽃을 보며 행운을 느낄 수 있어요. 단, 번식력이 강해 포기를 나누고, 수액이 피부에 닿지 않게 주의하며, 갈변하는 잎 끝을 잘라내야 한답니다. 병충해에도 강해서 초보자도 약간의 관리만 해주면 튼튼하게 자라는 식물이에요.",
-            imagePath: "https://seeat-image-dev-image-bucket.s3.ap-northeast-2.amazonaws.com/%E1%84%80%E1%85%AA%E1%86%AB%E1%84%8B%E1%85%B3%E1%86%B7%E1%84%8C%E1%85%AE%E1%86%A8.png",
+            imagePath: "https://seeat-image-dev-image-bucket.s3.ap-northeast-2.amazonaws.com/%E1%84%80%E1%85%AA%E1%86%AB%E1%84%8B%E1%85%B3%E1%86%B7%E1%84%8C%E1%85%AE%E1%86%A8_full.png",
             thumbnailPath: "https://seeat-image-dev-image-bucket.s3.ap-northeast-2.amazonaws.com/%E1%84%80%E1%85%AA%E1%86%AB%E1%84%8B%E1%85%B3%E1%86%B7%E1%84%8C%E1%85%AE%E1%86%A8.png"
         },
         //스투키 id : 5
@@ -65,7 +65,7 @@ const reset = async () => {
                 "3. 번식이 빠르기 때문에 새순이 나오면 바로 분갈이를 해야 해요.",
             description: "쾌적한 집콕 라이프 추천",
             ment: "스투키는 NASA에서 추천했을 정도로 탁월한 공기 정화 능력을 가지고 있어요. 스투키는 햇빛에도 강하고 집안 어디에서나 키워도 무리없이 잘 자라기 때문에 초보자가 키우기에 적합한 반려식물이랍니다. 비교적 추위에도 강한 편이지만 겨울엔 실내로 옮겨주시는 게 좋아요.  스투키는 매우 다양한 사이즈와 굵기를 가지고 있어요. 내 취향에 맞는 스투키를 찾아보는 것도 재미있는 여정이 될 거에요.",
-            imagePath: "https://seeat-image-dev-image-bucket.s3.ap-northeast-2.amazonaws.com/%E1%84%89%E1%85%B3%E1%84%90%E1%85%AE%E1%84%8F%E1%85%B5.png",
+            imagePath: "https://seeat-image-dev-image-bucket.s3.ap-northeast-2.amazonaws.com/%E1%84%89%E1%85%B3%E1%84%90%E1%85%AE%E1%84%8F%E1%85%B5_full.png",
             thumbnailPath: "https://seeat-image-dev-image-bucket.s3.ap-northeast-2.amazonaws.com/%E1%84%89%E1%85%B3%E1%84%90%E1%85%AE%E1%84%8F%E1%85%B5.png"
         },
         //올리브 나무 id : 6
@@ -79,7 +79,7 @@ const reset = async () => {
                 "4. 2년에 한번 전체적인 분갈이를 진행해주면 적당해요.",
             description: "몸과 마음이 치유되는 사계절",
             ment: "올리브 나무는 그 잎을 사계절 내내 감상하는 것 만으로 매우 훌륭한 가치를 가지고 있는 반려식물이에요. 해외에서만 만날 수 있던 과거와 달리 요즘에는 일반 꽃집에서도 심심치 않게 볼 수 있을 정도로 친근해졌어요. 풍성한 꽃과 열매를 수확할 수 있는 것도 올리브 나무의 큰 장점이죠. 사계절 다양한 모습 올리브 나무와 함께라면 집에 있는 시간도 더 이상 지루하게 느껴지지 않을 거에요. ",
-            imagePath: "https://seeat-image-dev-image-bucket.s3.ap-northeast-2.amazonaws.com/%E1%84%8B%E1%85%A9%E1%86%AF%E1%84%85%E1%85%B5%E1%84%87%E1%85%B3%E1%84%82%E1%85%A1%E1%84%86%E1%85%AE.png",
+            imagePath: "https://seeat-image-dev-image-bucket.s3.ap-northeast-2.amazonaws.com/%E1%84%8B%E1%85%A9%E1%86%AF%E1%84%85%E1%85%B5%E1%84%87%E1%85%B3%E1%84%82%E1%85%A1%E1%84%86%E1%85%AE_full.png",
             thumbnailPath: "https://seeat-image-dev-image-bucket.s3.ap-northeast-2.amazonaws.com/%E1%84%8B%E1%85%A9%E1%86%AF%E1%84%85%E1%85%B5%E1%84%87%E1%85%B3%E1%84%82%E1%85%A1%E1%84%86%E1%85%AE.png"
         },
         //행운목 id : 7
@@ -93,7 +93,7 @@ const reset = async () => {
                 "4. 4~5년에 한 번 여름에 분갈이를 진행해 주세요.",
             description: "꽃을 기다리는 달콤한 시간",
             ment: "행운목은 몇 년에 한 번 긴 주기로 꽃을 피우는 식물이에요. 그렇기 때문에 행운목에 꽃이 피는 해는 행운이 가득하다고 해서 행운목이라는 이름이 붙었답니다. 행운목에 꽃이 피면 기분 좋은 달콤한 향을 느낄 수 있어요. 따스하게 행운목을 관리해주며 꽃을 기다려 보는 것도 좋은 추억이 될 거 같아요. 행운목과 함께라면 매일매일 기대감 넘치는 하루를 보낼 수 있지 않을까요? ",
-            imagePath: "https://seeat-image-dev-image-bucket.s3.ap-northeast-2.amazonaws.com/%E1%84%92%E1%85%A2%E1%86%BC%E1%84%8B%E1%85%AE%E1%86%AB%E1%84%86%E1%85%A9%E1%86%A8.png",
+            imagePath: "https://seeat-image-dev-image-bucket.s3.ap-northeast-2.amazonaws.com/%E1%84%92%E1%85%A2%E1%86%BC%E1%84%8B%E1%85%AE%E1%86%AB%E1%84%86%E1%85%A9%E1%86%A8_full.png",
             thumbnailPath: "https://seeat-image-dev-image-bucket.s3.ap-northeast-2.amazonaws.com/%E1%84%92%E1%85%A2%E1%86%BC%E1%84%8B%E1%85%AE%E1%86%AB%E1%84%86%E1%85%A9%E1%86%A8.png"
         },
         //돈나무 id : 8
@@ -106,7 +106,7 @@ const reset = async () => {
                 "3. 1년에 한 번 정도 알뿌리에 손상이 가지 않게 분갈이를 진행해주세요.",
             description: "돈이 들어오는 행운의 나무",
             ment: "돈나무는 잎의 모양이 동전 모양을 닮아있어요. 그렇기 때문에 돈이 들어오는 나무라고 해서 금전수라고도 불러요. 그래서인지 돈나무는 집들이나 개업 선물로도 아주 인기가 많답니다. 다른 식물들에 비해 생명력이 아주 뛰어나서 직사광선 및 물주기만 조심해준다면 초보자도 충분히 키울 수 있어요. 자주 물을 줄 필요가 없고 꼼꼼한 관리 없이도 잘 자란다는 게 아주 큰 장점이죠. 돈나무와 함께 우리도 오늘부터 황금빛 미래를 그려볼까요? ",
-            imagePath: "https://seeat-image-dev-image-bucket.s3.ap-northeast-2.amazonaws.com/%E1%84%83%E1%85%A9%E1%86%AB%E1%84%82%E1%85%A1%E1%84%86%E1%85%AE.png",
+            imagePath: "https://seeat-image-dev-image-bucket.s3.ap-northeast-2.amazonaws.com/%E1%84%83%E1%85%A9%E1%86%AB%E1%84%82%E1%85%A1%E1%84%86%E1%85%AE_full.png",
             thumbnailPath: "https://seeat-image-dev-image-bucket.s3.ap-northeast-2.amazonaws.com/%E1%84%83%E1%85%A9%E1%86%AB%E1%84%82%E1%85%A1%E1%84%86%E1%85%AE.png"
         },
         //스파티필름 id : 9
@@ -118,7 +118,7 @@ const reset = async () => {
                 "2. 1~2년에 한 번 분갈이가 필요하며, 분갈이 직후에는 말뚝을 사용해 일정 기간동안 지지대를 만들어주세요.",
             description: "나사가 인정한 공기정화식물",
             ment: "덥고 습한 곳에서 잘 자라는 식물인 스파티필름은 내 방에서 함께할 수 있는 반려식물이에요. 스파티필름은 NASA에서 추천한 공기 정화 식물 중 하나기도 하답니다. 건조에는 약하고 습기에는 강하기 때문에 잎이 마르지 않도록 조심해주는 게 중요해요. 온도나 습도가 적당하면 언제든지 꽃을 피우는 식물이기 때문에, 꽃을 좋아하는 분이라면 스파티필름이 좋은 친구가 되어줄 거 같아요. ",
-            imagePath: "https://seeat-image-dev-image-bucket.s3.ap-northeast-2.amazonaws.com/%E1%84%89%E1%85%B3%E1%84%91%E1%85%A1%E1%84%90%E1%85%B5%E1%84%91%E1%85%B5%E1%86%AF%E1%84%85%E1%85%B3%E1%86%B7.png",
+            imagePath: "https://seeat-image-dev-image-bucket.s3.ap-northeast-2.amazonaws.com/%E1%84%89%E1%85%B3%E1%84%91%E1%85%A1%E1%84%90%E1%85%B5%E1%84%91%E1%85%B5%E1%86%AF%E1%84%85%E1%85%B3%E1%86%B7_full.png",
             thumbnailPath: "https://seeat-image-dev-image-bucket.s3.ap-northeast-2.amazonaws.com/%E1%84%89%E1%85%B3%E1%84%91%E1%85%A1%E1%84%90%E1%85%B5%E1%84%91%E1%85%B5%E1%86%AF%E1%84%85%E1%85%B3%E1%86%B7.png"
         },
         //필레아페페 id : 10
@@ -131,7 +131,7 @@ const reset = async () => {
                 "3. 일반 분갈이 흙과 마사를 7:3 정도의 비율로 섞어서 심으면 물 빠짐도 좋고 성장과 번식에도 도움이 돼요.",
             description: "전자파를 차단하는 싱그러움",
             ment: "필레아페페는 필레아 페페로미오이데스라는 멋진 풀네임을 가지고 있어요. 동그란 잎의 모양이 중국 동전을 닮았다고 해 중국동전풀이라는 별명이 있기도 해요. 필레아페페는 추위에 약한 식물이기 때문에 온도가 10도 이하로 떨어지지 않도록 주의해줘야 해요. 번식이 매우 잘되는 식물이기 때문에 땅에서 올라오는 자구를 삽목하면 필레아페페 대가족을 만들 수 있답니다! 훨씬 싱그러워진 우리 집을 발견할 수 있을 거에요. ",
-            imagePath: "https://seeat-image-dev-image-bucket.s3.ap-northeast-2.amazonaws.com/%E1%84%91%E1%85%B5%E1%86%AF%E1%84%85%E1%85%A6%E1%84%8B%E1%85%A1%E1%84%91%E1%85%A6%E1%84%91%E1%85%A6.png",
+            imagePath: "https://seeat-image-dev-image-bucket.s3.ap-northeast-2.amazonaws.com/%E1%84%91%E1%85%B5%E1%86%AF%E1%84%85%E1%85%A6%E1%84%8B%E1%85%A1%E1%84%91%E1%85%A6%E1%84%91%E1%85%A6_full.png",
             thumbnailPath: "https://seeat-image-dev-image-bucket.s3.ap-northeast-2.amazonaws.com/%E1%84%91%E1%85%B5%E1%86%AF%E1%84%85%E1%85%A6%E1%84%8B%E1%85%A1%E1%84%91%E1%85%A6%E1%84%91%E1%85%A6.png"
         },
         //스킨답서스 id : 11
@@ -142,7 +142,7 @@ const reset = async () => {
                 "2. 분갈이 후 몸살이 있는 편이라 너무 자주 해주는 건 좋지 않아요.",
             description: "취향대로 고르는 즐거움",
             ment: "스킨답서스는 마블, 라임, 엔조이 등 색이나 무늬가 다른 여러 종류가 있어요. 그렇기 때문에 취향에 맞는 다양한 스킨답서스 친구들을 들일 수 있다는 게 아주 큰 장점이죠. 크게 신경써서 관리해야 할 부분이기 때문에 초보자에게 적합한 반려 식물 중 하나에요. 까다롭지 않은 친구지만 너무 추운 추위는 조심해줄 필요가 있어요. 식물 키우기에 자신이 없는 초보 분들이라면 스킨답서스를 첫 친구로 들여보시는 건 어떨까요?",
-            imagePath: "https://seeat-image-dev-image-bucket.s3.ap-northeast-2.amazonaws.com/%E1%84%89%E1%85%B3%E1%84%8F%E1%85%B5%E1%86%AB%E1%84%83%E1%85%A1%E1%86%B8%E1%84%89%E1%85%A5%E1%84%89%E1%85%B3.png",
+            imagePath: "https://seeat-image-dev-image-bucket.s3.ap-northeast-2.amazonaws.com/%E1%84%89%E1%85%B3%E1%84%8F%E1%85%B5%E1%86%AB%E1%84%83%E1%85%A1%E1%86%B8%E1%84%89%E1%85%A5%E1%84%89%E1%85%B3_full.png",
             thumbnailPath: "https://seeat-image-dev-image-bucket.s3.ap-northeast-2.amazonaws.com/%E1%84%89%E1%85%B3%E1%84%8F%E1%85%B5%E1%86%AB%E1%84%83%E1%85%A1%E1%86%B8%E1%84%89%E1%85%A5%E1%84%89%E1%85%B3.png"
         },
         //트리안 id : 12
@@ -154,7 +154,7 @@ const reset = async () => {
                 "3. 1~2년 주기로 분갈이를 해줘야 해요.",
             description: "섬세함으로 채워가는 공간",
             ment: "트리안은 모빌처럼 길게 늘어져 자라는 가늘고 섬세한 줄기가 매력적인 친구에요. 열대 지방 식물이기 때문에 따뜻한 기온을 유지해주는 것이 중요해요. 줄기를 잘라주면 새로운 줄기가 더 잘 자라는 특성을 갖고 있기 때문에 지속적으로 관리해주면 점점 더 멋진 모습으로 자라날 거에요. 트리안과 함께라면 우리 집도 개성만점 멋진 모습으로 재탄생할 수 있을 거 같아요!",
-            imagePath: "https://seeat-image-dev-image-bucket.s3.ap-northeast-2.amazonaws.com/%E1%84%90%E1%85%B3%E1%84%85%E1%85%B5%E1%84%8B%E1%85%A1%E1%86%AB.png",
+            imagePath: "https://seeat-image-dev-image-bucket.s3.ap-northeast-2.amazonaws.com/%E1%84%90%E1%85%B3%E1%84%85%E1%85%B5%E1%84%8B%E1%85%A1%E1%86%AB_full.png",
             thumbnailPath: "https://seeat-image-dev-image-bucket.s3.ap-northeast-2.amazonaws.com/%E1%84%90%E1%85%B3%E1%84%85%E1%85%B5%E1%84%8B%E1%85%A1%E1%86%AB.png"
         },
         //마리모 id : 13
@@ -166,7 +166,7 @@ const reset = async () => {
                 "3. 일주일에 한 번 물갈이를 해주세요.",
             description: "꼬물꼬물 귀여운 행운의 상징",
             ment: "대부분의 시간을 바닥에서 지내는 마리모는 어느 날 물 위로 동동 떠오르곤 해요. 사람들은 이를 보며 마리모가 기분이 좋아서 물 위로 떠오른다고 하죠. 또한 마리모가 물에 뜨면 그 날엔 행운이 찾아온다는 속설이 있어요. 마리모는 수족관에서도 잘 지내기 때문에 물고기를 키우는 집이라면 강력 추천! 다양한 유리병과 함께라면 마리모는 색다른 인상을 심어주는 좋은 친구가 되어주기도 해요. ",
-            imagePath: "https://seeat-image-dev-image-bucket.s3.ap-northeast-2.amazonaws.com/%E1%84%86%E1%85%A1%E1%84%85%E1%85%B5%E1%84%86%E1%85%A9.png",
+            imagePath: "https://seeat-image-dev-image-bucket.s3.ap-northeast-2.amazonaws.com/%E1%84%86%E1%85%A1%E1%84%85%E1%85%B5%E1%84%86%E1%85%A9_full.png",
             thumbnailPath: "https://seeat-image-dev-image-bucket.s3.ap-northeast-2.amazonaws.com/%E1%84%86%E1%85%A1%E1%84%85%E1%85%B5%E1%84%86%E1%85%A9.png"
         },
         //벵갈고무나무 id : 14
@@ -177,7 +177,7 @@ const reset = async () => {
                 "2. 관리 난이도가 높아요. 한 여름 철의 땡볕은 꼭 피하고, 기온이 10℃ 미만으로 내려가지 않도록 주의하고, 겨울철에도 어느 정도 통풍에 신경써줘야 해요.",
             description: "당신을 위한 영원한 행복",
             ment: "뱅갈고무나무는 영원한 행복이라는 멋진 꽃말을 가지고 있어요. 인도에서는 장수와 풍요의 상징으로 신성시되는 나무 중 하나랍니다. 다른 반려 식물들에 비해 조금 관리에 노력을 쏟아야하는 친구에요. 가지가 잘 뻗고 옆으로 퍼지며 자라는 친구라 가정에서 키우기 적합해요. 겉모습이 큼직큼직해 시원하고 멋진 느낌을 주는 뱅갈고무나무와 새로운 도전을 시작해보는 건 어떨까요? ",
-            imagePath: "https://seeat-image-dev-image-bucket.s3.ap-northeast-2.amazonaws.com/%E1%84%87%E1%85%A6%E1%86%BC%E1%84%80%E1%85%A1%E1%86%AF%E1%84%80%E1%85%A9%E1%84%86%E1%85%AE%E1%84%82%E1%85%A1%E1%84%86%E1%85%AE.png",
+            imagePath: "https://seeat-image-dev-image-bucket.s3.ap-northeast-2.amazonaws.com/%E1%84%87%E1%85%A6%E1%86%BC%E1%84%80%E1%85%A1%E1%86%AF%E1%84%80%E1%85%A9%E1%84%86%E1%85%AE%E1%84%82%E1%85%A1%E1%84%86%E1%85%AE_full.png",
             thumbnailPath: "https://seeat-image-dev-image-bucket.s3.ap-northeast-2.amazonaws.com/%E1%84%87%E1%85%A6%E1%86%BC%E1%84%80%E1%85%A1%E1%86%AF%E1%84%80%E1%85%A9%E1%84%86%E1%85%AE%E1%84%82%E1%85%A1%E1%84%86%E1%85%AE.png"
         },
         //디시디아 id : 15
@@ -189,7 +189,7 @@ const reset = async () => {
                 "2. 너무 습하면 곰팡이가 생길 수 있으니 통풍에 신경 써주세요",
             description: "남들과 다른 독특한 매력",
             ment: "디시디아는 아직 국내에는 많이 알려지지 않은 레어한 반려식물이에요. 디시디아는 다른 나무에 붙어 살며 양분을 흡수하는 착생식물이랍니다. 흙 대신 코코넛 껍질 등에 뿌리를 내린 채 자라요. 흙을 필요로 하지 않고 화분이 필요하지 않으며, 길게 자라기 때문에 인테리어 식물로 각광받고 있어요. 남들과 다른 나만의 멋진 식물을 찾고 있다면 디시디아와 친구가 되어보는 건 어떨까요? ",
-            imagePath: "https://seeat-image-dev-image-bucket.s3.ap-northeast-2.amazonaws.com/%E1%84%83%E1%85%B5%E1%84%89%E1%85%B5%E1%84%83%E1%85%B5%E1%84%8B%E1%85%A1.png",
+            imagePath: "https://seeat-image-dev-image-bucket.s3.ap-northeast-2.amazonaws.com/%E1%84%83%E1%85%B5%E1%84%89%E1%85%B5%E1%84%83%E1%85%B5%E1%84%8B%E1%85%A1_full.png",
             thumbnailPath: "https://seeat-image-dev-image-bucket.s3.ap-northeast-2.amazonaws.com/%E1%84%83%E1%85%B5%E1%84%89%E1%85%B5%E1%84%83%E1%85%B5%E1%84%8B%E1%85%A1.png"
         },
     ]);


### PR DESCRIPTION
<img width="823" alt="스크린샷 2021-02-13 오후 6 49 27" src="https://user-images.githubusercontent.com/59886140/107847122-33b44280-6e2c-11eb-970e-d80d44b9fefb.png">

현재 풀사이즈 이미지의 경우 _full.png 와 같이 파일 확장자 앞에 _full 을 붙이는 규칙을 잡았습니다.

따라서 imagePath 에는 썸네일파일주소_full.png 와 같이 응답할 수 있도록 데이터 수정하였습니다. 