### PR TITLE
[chore] change load balancing algorithm

### DIFF
--- a/backend/docker-compose.yml
+++ b/backend/docker-compose.yml
@@ -36,3 +36,31 @@ services:
     expose:
       - "4000"
     restart: "unless-stopped"
+  express_5:
+    build:
+      context: .
+    container_name: express5
+    expose:
+      - "4000"
+    restart: "unless-stopped"
+  express_6:
+    build:
+      context: .
+    container_name: express6
+    expose:
+      - "4000"
+    restart: "unless-stopped"
+  express_7:
+    build:
+      context: .
+    container_name: express7
+    expose:
+      - "4000"
+    restart: "unless-stopped"
+  express_8:
+    build:
+      context: .
+    container_name: express8
+    expose:
+      - "4000"
+    restart: "unless-stopped"

--- a/backend/nginx.conf
+++ b/backend/nginx.conf
@@ -13,11 +13,15 @@ http {
     default_type  application/octet-stream;
 
     upstream docker-express { # 1
-        least_conn;
+        ip_hash;
         server express1:4000 weight=10;
         server express2:4000 weight=10;
         server express3:4000 weight=10;
         server express4:4000 weight=10;
+        server express5:4000 weight=10;
+        server express6:4000 weight=10;
+        server express7:4000 weight=10;
+        server express8:4000 weight=10;
     }
 
     server {


### PR DESCRIPTION
- least connection -> ip_hash
- add 4 more containers

기존 nginx 리버스 프록시 서버의 로드밸런싱 알고리즘이 제일 연결이 적은 서버에 연결하는 로직이였습니다.

하지만 서비스 특성상 동일한 Ip를 가진 유저가 여러번 호출하게 되기 떄문에, 같은 IP로 들어오는 요청은 하나의 서버에서 분담해서 처리하는 ip_hash로 알고리즘을 변경하였습니다.

<img width="1645" alt="스크린샷 2021-02-13 오후 10 00 10" src="https://user-images.githubusercontent.com/59886140/107850657-54d65c80-6e47-11eb-88db-ec3215083ff5.png">

실제 테스트해보면 4개 골고루 로드밸런싱이 되는 상태였습니다.

nginx 설정에 대한 내용은 공식문서를 참고했어요

https://docs.nginx.com/nginx/deployment-guides/load-balance-third-party/node-js/

또한 현재 4개의 도커 컨테이너를 올리도록 되어있었는데, 서버 메모리가 여유가 있는 것 같아서 8개로 증설해보려고 합니다 :)