### PR TITLE
[feat] change some parameters in nginx.conf for enhancing

### DIFF
--- a/backend/nginx.conf
+++ b/backend/nginx.conf
@@ -1,16 +1,32 @@
 user  nginx;
 worker_processes  1;
 
-error_log  /var/log/nginx/error.log warn;
+#크리티컬한 로그만 저장, CPU I/O 향상
+error_log  /var/log/nginx/error.log crit;
 pid        /var/run/nginx.pid;
 
 events {
-    worker_connections  1024;
+    worker_connections  4000;
 }
 
 http {
     include       /etc/nginx/mime.types;
     default_type  application/octet-stream;
+    open_file_cache max=200000 inactive=20s;
+    open_file_cache_valid 30s;
+    open_file_cache_min_uses 2;
+    open_file_cache_errors on;
+    # I/O 부스팅을 위해 엑세스 로그를 끔.
+    access_log off;
+    sendfile on;
+
+    #tcp header를 배치처리
+    tcp_nopush on;
+    tcp_nodelay on;
+
+    #timed out connection 리셋 on
+    reset_timedout_connection on;
+    keepalive_timeout 30;
 
     upstream docker-express { # 1
         ip_hash;
@@ -26,7 +42,7 @@ http {
 
     server {
         listen 80;
-        server_name 3.34.87.77 sehwanzzang.com;
+        server_name 3.34.87.77 sehwanzzang.com api.sehwanzzang.com; #향후 api.도메인명.com 으로 api 서버 운영 예정
 
         location / {
 		proxy_http_version 1.1;
@@ -41,7 +57,5 @@ http {
 
     access_log  /var/log/nginx/access.log  main;
 
-    sendfile        on;
-    keepalive_timeout  65;
     include /etc/nginx/conf.d/*.conf;
 }


### PR DESCRIPTION
#119 이후 여러번 테스트를 걸쳐 nginx 튜닝을 완료하였습니다.

https://gist.github.com/denji/8359866 

위 내용을 많이 참고했습니다.

또한 지금 현재 구조는 api 요청이 ec2 서버로 바로 요청이 들어오는 구조인데, 서버의 부담이 매우 큰 상태였습니다.

따라서 CDN 서비스 (aws cloudfront)를 활용하여 최대한 캐싱된 결과를 전달하고, https 를 적용하여 퍼포먼스를 향상시켰습니다.

nginx 튜닝 + CDN 으로 혹시 모를(?) 트래픽 대응이 가능할것 같아요 !_!


## AS-IS : CDN 적용 전, nginx 튜닝 전

![스크린샷 2021-02-17 오후 11 00 43](https://user-images.githubusercontent.com/59886140/108239594-68f2c480-718d-11eb-8768-a40f172a8942.png)

<img width="833" alt="스크린샷 2021-02-17 오후 11 26 07" src="https://user-images.githubusercontent.com/59886140/108239613-6ee8a580-718d-11eb-933c-c37454c029c4.png">

최대 동시접속자수는 /backend/test.json에 약 12000 동접을 하도록 테스트하였으므로 서버가 뻗지 않는 선에서 12000명 가까이 나왔습니다. 

## TO-BE : CDN 적용, nginx 튜닝 후

![스크린샷 2021-02-18 오전 1 41 10](https://user-images.githubusercontent.com/59886140/108239921-b3744100-718d-11eb-964e-fa2ae3f947f8.png)

<img width="1653" alt="스크린샷 2021-02-18 오전 1 40 12" src="https://user-images.githubusercontent.com/59886140/108240017-c9820180-718d-11eb-9335-d8e7e6631c01.png">



현재 http 적용된 임시 api 서버 : https://api.sehwanzzang.com/