### PR TITLE
[chore] add removing cache logic for cloudfront

### DIFF
--- a/backend/jenkins/front.groovy
+++ b/backend/jenkins/front.groovy
@@ -27,6 +27,7 @@ pipeline {
             steps {
                 dir('frontend'){
                 sh "aws s3 sync ./build s3://dnd-4th-9-see-at --profile default"
+                sh "aws cloudfront create-invalidation --distribution-id E2P190XS1LK5MX --paths '/*' --profile default"
                 echo 'deploy done.'
                 }
             }


### PR DESCRIPTION
현재 사용자가 씨앗 웹을 접속하면, Cloudfront 가 캐쉬하고 있는 웹 관련 파일들을 전송합니다. (저희가 파일을 저장한 S3 버킷을 직접 엑세스 하는게 아닌 상태)

![스크린샷 2021-02-18 오후 9 02 15](https://user-images.githubusercontent.com/59886140/108354311-9e9aba80-722c-11eb-95a7-9420bb3a0cae.png)


새로운 배포가 진행되었을 때도 Cloudfront가 원본 파일이 바뀌었는지 체크를 매우 느린 주기로하기때문에, 강제로 캐쉬를 삭제해주는 명령어를 jenkins script에 작성하였습니다.

따라서 새로운 배포가 진행되었을 경우, 새로운 접속자들은 새로운 버전의 리액트 앱을 사용 할 수 있씁니다.