### PR TITLE
식물 디테일 페이지에 태그 목록 정렬하는 로직 추가 + 태그에 order 필드 추가.

### DIFF
--- a/backend/models/tag.model.js
+++ b/backend/models/tag.model.js
@@ -11,6 +11,10 @@ module.exports = class Tag extends Sequelize.Model{
             type: {
                 type: Sequelize.STRING(50),
                 allowNull: false,
+            },
+            order : {
+                type: Sequelize.INTEGER,
+                allowNull: false
             }
         }, {
             sequelize,

--- a/backend/services/plantService.js
+++ b/backend/services/plantService.js
@@ -92,13 +92,15 @@ const detailPlant = async(plantDTO) => {
             attributes: [],
             include: [{
                 model: Tag,
-                attributes: ['name'],
+                attributes: ['name', 'order'],
                 through: {
-                    attributes: []
-                }
+                    attributes: [],
+                },
             }],
+            order:[[Tag , 'order', 'ASC']]
         });
 
+        // tag들 정렬하는 로직, order 필드 값을 보고 정
         const tags = additonalResult.get({
             plain: true
         });
@@ -167,7 +169,7 @@ const getCuratingResult = async(plantDTO) => {
                 attributes: ['id', 'name'],
                 through: {
                     attributes: []
-                }
+                },
             }]
         });
         return result;

--- a/backend/services/plantService.js
+++ b/backend/services/plantService.js
@@ -92,7 +92,7 @@ const detailPlant = async(plantDTO) => {
             attributes: [],
             include: [{
                 model: Tag,
-                attributes: ['name', 'order'],
+                attributes: ['name'],
                 through: {
                     attributes: [],
                 },

--- a/backend/services/plantService.js
+++ b/backend/services/plantService.js
@@ -100,7 +100,6 @@ const detailPlant = async(plantDTO) => {
             order:[[Tag , 'order', 'ASC']]
         });
 
-        // tag들 정렬하는 로직, order 필드 값을 보고 정
         const tags = additonalResult.get({
             plain: true
         });

--- a/backend/setup.js
+++ b/backend/setup.js
@@ -196,71 +196,88 @@ const reset = async () => {
     await db.Tag.bulkCreate([
         {
             name: "💧💧💧", // id : 1
-            type: "물주기"
+            type: "물주기",
+            order: 2
         },
         {
             name: "💧", // id : 2
-            type: "물주기"
+            type: "물주기",
+            order: 2
         },
         {
             name: "#잎도촉촉히", // id : 3
-            type: "물주기"
+            type: "물주기",
+            order: 2
         },
         {
             name: "#작은크기", // id : 4
-            type: "크기"
+            type: "크기",
+            order: 3
         },
         {
             name: "#보통크기", // id : 5
-            type: "크기"
+            type: "크기",
+            order: 3
         },
         {
             name: "#큰", // id : 6
-            type: "크기"
+            type: "크기",
+            order: 3
         },
         {
             name: "#꽃", // id : 7
-            type: "꽃/열매"
+            type: "꽃/열매",
+            order: 4
         },
         {
             name: "#열매", // id : 8
-            type: "꽃/열매"
+            type: "꽃/열매",
+            order: 4
         },
         {
             name: "#그늘에서", // id : 9
-            type: "장소"
+            type: "장소",
+            order: 5
         },
         {
             name: "#환한곳에서", // id : 10
-            type: "장소"
+            type: "장소",
+            order: 5
         },
         {
             name: "#쑥쑥자라요", // id : 11
-            type: "속도"
+            type: "속도",
+            order: 6
         },
         {
             name: "#처음모습그대로", // id : 12
-            type: "속도"
+            type: "속도",
+            order: 6
         },
         {
             name: "#적당히포근하게", // id : 13
-            type: "온도"
+            type: "온도",
+            order: 7
         },
         {
             name: "#따뜻하게", // id : 14
-            type: "온도"
+            type: "온도",
+            order: 7
         },
         {
             name: "⭐", // id : 15
-            type: "난이도"
+            type: "난이도",
+            order: 1
         },
         {
             name: "⭐⭐", // id : 16
-            type: "난이도"
+            type: "난이도",
+            order: 1
         },
         {
             name: "⭐⭐⭐", // id : 17
-            type: "난이도"
+            type: "난이도",
+            order: 1
         }
     ])
 


### PR DESCRIPTION
resolve : #122 

식물 디테일 페이지에 필요한 태그 목록을 정렬하는 로직을 추가하였습니다.

태그의 우선순위(?) 에 대한 대응이 필요한 시점이라 이렇게 필드 하나 추가했습니다. 

tag의 type이라는 새로운 테이블을 만들어서.. 거기서 tag에 대한 디테일한 내용들이 들어가도록 모델링을 다시 해야 할 것 같긴 합니다만..!

시간이 많지 않으니 우선 이렇게 😂

## AS-IS

```json
  "allTags": [
    { "name": "💧💧💧" },
    { "name": "#보통크기" },
    { "name": "#꽃" },
    { "name": "#열매" },
    { "name": "#그늘에서" },
    { "name": "#쑥쑥자라요" },
    { "name": "#적당히포근하게" },
    { "name": "⭐" }
  ],
```

## TO-BE

```json
  "allTags": [
    { "name": "⭐" },
    { "name": "💧💧💧" },
    { "name": "#보통크기" },
    { "name": "#열매" },
    { "name": "#꽃" },
    { "name": "#그늘에서" },
    { "name": "#쑥쑥자라요" },
    { "name": "#적당히포근하게" }
  ],
```

감사합니다! @1000peach 