### PR TITLE
cors policy

### DIFF
--- a/backend/app.js
+++ b/backend/app.js
@@ -47,11 +47,18 @@ class App {
   }
 
   setMiddleWare() {
-    this.app.use(morgan('dev'));
+    if (process.env.NODE_ENV === 'production') {
+      this.app.use(morgan('combined'));
+      this.app.use(
+        cors({origin: 'https://www.seeat-plant.com', credentials: true})
+      );
+    } else {
+      this.app.use(morgan('dev'));
+      this.app.use(cors({origin: true, credentials: true}));
+    }
     this.app.use(express.json());
     this.app.use(express.urlencoded({extended: false}));
     this.app.use(express.static(path.join(__dirname, 'public')));
-    this.app.use(cors({origin: true, credentials: true}));
     this.app.use(cookieParser(process.env.SECRET_KEY));
     this.app.use(
       session({


### PR DESCRIPTION
#141 
cors 정책 production이랑 dev로 분리했습니다. 
 개발용 api 따로 구축하지 않고 .env에 `NODE_ENV = production`  이것만 바꿔서 사용하시면 됩니다. 

@kimsehwan96  .env에  `NODE_ENV = production` 이것만 추가해서 테스트 부탁드립니다! 

겸사겸사 morgan에서 찍어주는 로그도 production 환경에서 다르게 맞춰놨습니다. 