### PR TITLE
API 서버 부하테스트 타겟서버 수정 및 NGINX 로드밸런스 방식 변경

### DIFF
--- a/backend/nginx.conf
+++ b/backend/nginx.conf
@@ -29,7 +29,7 @@ http {
     keepalive_timeout 30;
 
     upstream docker-express { # 1
-        ip_hash;
+        least_conn;
         server express1:4000 weight=10;
         server express2:4000 weight=10;
         server express3:4000 weight=10;

--- a/backend/test.json
+++ b/backend/test.json
@@ -1,6 +1,6 @@
 {
   "config": {
-    "target": "http://3.34.87.77",
+    "target": "https://api.seeat-plant.com",
     "phases": [
       {
         "duration": 60,


### PR DESCRIPTION
기존 로드 밸런스 로직을 `ip_hash` 에서 `least_conn`으로 수정합니다. 