### PR TITLE
추천 식물 리스트 정렬 로직 반영

### DIFF
--- a/backend/services/plantService.js
+++ b/backend/services/plantService.js
@@ -159,7 +159,38 @@ const detailPlant = async (plantDTO) => {
       return count > 4;
     };
 
-    const recommendPlants = allPlants.filter((plant) => isRecommended(plant));
+    /*
+      @params: Plants : Plant[]
+    */
+    const orderPlants = (Plants) => {
+      Plants.map((Plant) => {
+        const tags = Plant.get({
+          plain: true,
+        })['Tags'];
+
+        const count = tags
+          .map((tag) => tag.name)
+          .filter((item) => recommendTag.includes(item)).length;
+
+        Plant.matchedCount = count;
+      });
+      //객체 정렬
+      const order = (prev, curr) => {
+        return prev.matchedCount > curr.matchedCount
+          ? -1
+          : prev.matchedCount < curr.matchedCount
+          ? 1
+          : 0;
+      };
+
+      Plants.sort(order);
+
+      return Plants;
+    };
+
+    const recommendPlants = orderPlants(
+      allPlants.filter((plant) => isRecommended(plant))
+    );
 
     const detailResult = baseResult.get({
       plain: true,
@@ -202,6 +233,7 @@ const detailPlant = async (plantDTO) => {
         where: {id: plantDTO},
       }
     );
+
     return detailResult;
   } catch (error) {
     console.error(error);
@@ -261,7 +293,7 @@ const searchPlantTag = async (plantDTO) => {
           model: Tag,
           where: {
             name: {
-              [Op.in] : plantDTO
+              [Op.in]: plantDTO,
             },
           },
           attributes: [],
@@ -270,7 +302,9 @@ const searchPlantTag = async (plantDTO) => {
           },
         },
       ],
-      having: sequelize.literal(`COUNT(DISTINCT Tags.name) = ${plantDTO.length}`),
+      having: sequelize.literal(
+        `COUNT(DISTINCT Tags.name) = ${plantDTO.length}`
+      ),
       group: ['id'],
     });
     const plantIdArr = findPlantsIds


### PR DESCRIPTION
resolve: #163 

우선 기존에는 조회 대상 식물의 태그들과 나머지 전체 식물들의 태그 개수가 4개이상 겹칠경우 나머지 식물들을 추천 식물응답으로 그대로 주었는데,

새로운 로직을 추가하여서 **`매칭되는 태그 수가 많을수록`** 배열의 앞쪽에 오도록 수정하였습니다.

코드가 좀 별로긴 한데 나중에 리팩토링 하는걸로 ..ㅎㅎㅎ

밑에 응답은 `/plants/1` 호출 하였을 때의 응답을 보기 편하게 정리하여 작성했습니다.

## AS-IS

```json
{
  "id": 1,
  "name": "몬스테라",
  "recommendPlants": [
    {
      "id": 3,
      "name": "아이비"
    },
    {
      "id": 4,
      "name": "관음죽"
    },
    {
      "id": 9,
      "name": "스파티필름"
    },
    {
      "id": 10,
      "name": "필레아페페"
    }
  ]
}
```

## TO-BE

```json
{
  "id": 1,
  "name": "몬스테라",
  "recommendPlants": [
    {
      "id": 4,
      "name": "관음죽"
    },
    {
      "id": 3,
      "name": "아이비"
    },
    {
      "id": 9,
      "name": "스파티필름"
    },
    {
      "id": 10,
      "name": "필레아페페"
    }
  ]
}
```

감사합니다 ~!
